### PR TITLE
Fixed an error that occured in documents with page counts higher than 828.

### DIFF
--- a/createspace.dtx
+++ b/createspace.dtx
@@ -974,7 +974,7 @@
 \PackageWarning{createspace}{book requires at least \the\createspace@c@minpages\space pages to be published, yours has only \the\createspace@c@pages}
 \fi
 \ifnum\createspace@c@pages>\createspace@c@maxpages
-\PackageWarning{createspace}{your book has \the\createspace@pages\space pages. This is more than the maximum allowed number of pages (\the\createspace@c@maxpages)}
+\PackageWarning{createspace}{your book has \the\createspace@c@pages\space pages. This is more than the maximum allowed number of pages (\the\createspace@c@maxpages)}
 \fi
 \ifcreatespace@industrystandard\else
 \createspace@PackageInfo{your book isn't available through Bookstores and Online Retailers Expanded Distribution Channel because it is prepared on custom trim size, you must use industry standard trim size.}

--- a/createspace.sty
+++ b/createspace.sty
@@ -656,7 +656,7 @@
 \PackageWarning{createspace}{book requires at least \the\createspace@c@minpages\space pages to be published, yours has only \the\createspace@c@pages}
 \fi
 \ifnum\createspace@c@pages>\createspace@c@maxpages
-\PackageWarning{createspace}{your book has \the\createspace@pages\space pages. This is more than the maximum allowed number of pages (\the\createspace@c@maxpages)}
+\PackageWarning{createspace}{your book has \the\createspace@c@pages\space pages. This is more than the maximum allowed number of pages (\the\createspace@c@maxpages)}
 \fi
 \ifcreatespace@industrystandard\else
 \createspace@PackageInfo{your book isn't available through Bookstores and Online Retailers Expanded Distribution Channel because it is prepared on custom trim size, you must use industry standard trim size.}


### PR DESCRIPTION
The root cause was because the warning message attempted to access a variable ("\createspace@pages") that was never defined, due to a typo probably. The correct variable name is "\createspace@c@pages".